### PR TITLE
Clarify help text.

### DIFF
--- a/plugins/repeater.rb
+++ b/plugins/repeater.rb
@@ -2,7 +2,7 @@ class Repeater
   include Cinch::Plugin
 
   $help_messages << "#{$settings['settings']['nick']}: ping       :pings everyone in the room"
-  $help_messages << "all: <message> ping everyone in the room"
+  $help_messages << "all: <message>       :broadcast notification to everyone in the room"
 
   listen_to :channel
 


### PR DESCRIPTION
The previous help text appeared to be a copied and slightly modified entry from the above line. Here we modify it to correctly show what operation will actually occur.

NOTE: The whitespace formatting may be incorrect. That was difficult to compare in the GitHub text editor.
