### PR TITLE
Fix language_mechanics to only allow string matching as full words

### DIFF
--- a/plugins/language_mechanics.rb
+++ b/plugins/language_mechanics.rb
@@ -16,10 +16,10 @@ class LanguageMechanics
   # look for poor grammar
   # i means
   # This uses a regular expression.
-  match /",/, method: :comma_outside_double_quote, use_prefix: false
-  match /"!/, method: :exclamation_point_outside_double_quote, use_prefix: false
-  match /"./, method: :period_outside_double_quote, use_prefix: false
-  match /"\?/, method: :question_mark_outside_double_quote, use_prefix: false
+  match /\b",(\s)?/, method: :comma_outside_double_quote, use_prefix: false
+  match /\b"!($)?/, method: :exclamation_point_outside_double_quote, use_prefix: false
+  match /\b".($)?/, method: :period_outside_double_quote, use_prefix: false
+  match /\b"\?($)?/, method: :question_mark_outside_double_quote, use_prefix: false
   match /\balot\b/i, method: :alot, use_prefix: false
   match /\bass\b/i, method: :ass, use_prefix: false
   match /coulda/i, method: :coulda, use_prefix: false
@@ -39,10 +39,11 @@ class LanguageMechanics
   match /who's is/i, method: :whos_is, use_prefix: false
   match /wtf/i, method: :wtf, use_prefix: false
 
+  #This outputs twice for some reason
   def comma_outside_double_quote(message)
     message.reply("It is correct to keep the punctuation inside of the quotations, not outside of them.")
   end
-
+  #This outputs twice for some reason
   def exclamation_point_outside_double_quote(message)
     message.reply("It is correct to keep the punctuation inside of the quotations, not outside of them.")
   end
@@ -50,7 +51,7 @@ class LanguageMechanics
   def period_outside_double_quote(message)
     message.reply("It is correct to keep the punctuation inside of the quotations, not outside of them.")
   end
-
+  #This outputs twice for some reason
   def question_mark_outside_double_quote(message)
     message.reply("It is correct to keep the punctuation inside of the quotations, not outside of them.")
   end

--- a/plugins/language_mechanics.rb
+++ b/plugins/language_mechanics.rb
@@ -20,11 +20,11 @@ class LanguageMechanics
   match /"!/, method: :exclamation_point_outside_double_quote, use_prefix: false
   match /"./, method: :period_outside_double_quote, use_prefix: false
   match /"\?/, method: :question_mark_outside_double_quote, use_prefix: false
-  match /alot/i, method: :alot, use_prefix: false
-  match /ass/i, method: :ass, use_prefix: false
+  match /\Aalot\z/i, method: :alot, use_prefix: false
+  match /\Aass\z/i, method: :ass, use_prefix: false
   match /coulda/i, method: :coulda, use_prefix: false
   match /couldve/i, method: :couldve, use_prefix: false
-  match /fuck/i, method: :fuck, use_prefix: false
+  match /\Afuck\z/i, method: :fuck, use_prefix: false
   match /if i was/i, method: :if_i_was, use_prefix: false
   match /irregardless/i, method: :irregardless, use_prefix: false
   match /l8r/i, method: :l8r, use_prefix: false
@@ -35,7 +35,7 @@ class LanguageMechanics
   match /sneak peak/i, method: :sneakpeak, use_prefix: false
   match /sneek peak/i, method: :sneekpeak, use_prefix: false
   match /sneek peek/i, method: :sneekpeek, use_prefix: false
-  match /shit/i, method: :shit, use_prefix: false
+  match /\Ashit\z/i, method: :shit, use_prefix: false
   match /who's is/i, method: :whos_is, use_prefix: false
   match /wtf/i, method: :wtf, use_prefix: false
 

--- a/plugins/language_mechanics.rb
+++ b/plugins/language_mechanics.rb
@@ -20,11 +20,11 @@ class LanguageMechanics
   match /"!/, method: :exclamation_point_outside_double_quote, use_prefix: false
   match /"./, method: :period_outside_double_quote, use_prefix: false
   match /"\?/, method: :question_mark_outside_double_quote, use_prefix: false
-  match /\Aalot\z/i, method: :alot, use_prefix: false
-  match /\Aass\z/i, method: :ass, use_prefix: false
+  match /\balot\b/i, method: :alot, use_prefix: false
+  match /\bass\b/i, method: :ass, use_prefix: false
   match /coulda/i, method: :coulda, use_prefix: false
   match /couldve/i, method: :couldve, use_prefix: false
-  match /\Afuck\z/i, method: :fuck, use_prefix: false
+  match /\bfuck\b/i, method: :fuck, use_prefix: false
   match /if i was/i, method: :if_i_was, use_prefix: false
   match /irregardless/i, method: :irregardless, use_prefix: false
   match /l8r/i, method: :l8r, use_prefix: false
@@ -35,7 +35,7 @@ class LanguageMechanics
   match /sneak peak/i, method: :sneakpeak, use_prefix: false
   match /sneek peak/i, method: :sneekpeak, use_prefix: false
   match /sneek peek/i, method: :sneekpeek, use_prefix: false
-  match /\Ashit\z/i, method: :shit, use_prefix: false
+  match /\bshit\b/i, method: :shit, use_prefix: false
   match /who's is/i, method: :whos_is, use_prefix: false
   match /wtf/i, method: :wtf, use_prefix: false
 

--- a/test/unit/language_mechanics_test.rb
+++ b/test/unit/language_mechanics_test.rb
@@ -52,6 +52,20 @@ class LanguageMechanicsTest < MiniTest::Test
     assert_equal "Unless you're referring to a donkey, please use a more courteous word. Options include \"arse\" and \"bum.\"", replies.first
   end
 
+  def test_class
+    bot = make_bot(LanguageMechanics)
+    message = make_message(bot, 'class')
+    replies = get_replies(message)
+    assert_equal nil, replies.first
+  end
+
+  def test_classes
+    bot = make_bot(LanguageMechanics)
+    message = make_message(bot, 'classes')
+    replies = get_replies(message)
+    assert_equal nil, replies.first
+  end
+
   def test_coulda
 
     # Create a bot. Pass the class name of your plugin

--- a/test/unit/language_mechanics_test.rb
+++ b/test/unit/language_mechanics_test.rb
@@ -45,25 +45,66 @@ class LanguageMechanicsTest < MiniTest::Test
   end
 
   def test_ass
-
     bot = make_bot(LanguageMechanics)
     message = make_message(bot, 'ass')
     replies = get_replies(message)
     assert_equal "Unless you're referring to a donkey, please use a more courteous word. Options include \"arse\" and \"bum.\"", replies.first
   end
 
-  def test_class
+  def test_ass_in_assassin
+    bot = make_bot(LanguageMechanics)
+    message = make_message(bot, 'assassin')
+    replies = get_replies(message)
+    assert_equal nil, replies.first
+  end
+
+  def test_ass_in_asshat
+    bot = make_bot(LanguageMechanics)
+    message = make_message(bot, 'asshat')
+    replies = get_replies(message)
+    assert_equal nil, replies.first
+  end
+
+  def test_ass_in_assface
+    bot = make_bot(LanguageMechanics)
+    message = make_message(bot, 'assface')
+    replies = get_replies(message)
+    assert_equal nil, replies.first
+  end
+
+  def test_ass_in_class
     bot = make_bot(LanguageMechanics)
     message = make_message(bot, 'class')
     replies = get_replies(message)
     assert_equal nil, replies.first
   end
 
-  def test_classes
+  def test_ass_in_classes
     bot = make_bot(LanguageMechanics)
     message = make_message(bot, 'classes')
     replies = get_replies(message)
     assert_equal nil, replies.first
+  end
+
+  def test_ass_in_sentence_beginning
+    bot = make_bot(LanguageMechanics)
+    message = make_message(bot, 'Ass hole')
+    replies = get_replies(message)
+    assert_equal "Unless you're referring to a donkey, please use a more courteous word. Options include \"arse\" and \"bum.\"", replies.first
+  end
+
+  def test_ass_in_sentence_ending
+    bot = make_bot(LanguageMechanics)
+    message = make_message(bot, 'You are an ass')
+    replies = get_replies(message)
+    assert_equal "Unless you're referring to a donkey, please use a more courteous word. Options include \"arse\" and \"bum.\"", replies.first
+  end
+
+  def test_ass_in_sentence_middle
+    bot = make_bot(LanguageMechanics)
+    message = make_message(bot, 'You are an ass hole')
+    replies = get_replies(message)
+    assert_equal "Unless you're referring to a donkey, please use a more courteous word. Options include \"arse\" and \"bum.\"", replies.first
   end
 
   def test_coulda

--- a/test/unit/language_mechanics_test.rb
+++ b/test/unit/language_mechanics_test.rb
@@ -9,32 +9,67 @@ class LanguageMechanicsTest < MiniTest::Test
 
   # Define your first test case.
   
+  def test_comma_inside_of_quotation
+    bot = make_bot(LanguageMechanics)
+    message = make_message(bot, '"hello,"')
+    replies = get_replies(message)
+    assert_equal nil, replies.first
+  end
+
   def test_comma_outside_of_quotation
     bot = make_bot(LanguageMechanics)
-    message = make_message(bot, '",')
+    message = make_message(bot, '"hello",')
     replies = get_replies(message)
     assert_equal "It is correct to keep the punctuation inside of the quotations, not outside of them.", replies.first
+  end
+
+  def test_exclamation_point_inside_of_quotation
+    bot = make_bot(LanguageMechanics)
+    message = make_message(bot, '"hello!"')
+    replies = get_replies(message)
+    assert_equal nil, replies.first
   end
 
   def test_exclamation_point_outside_of_quotation
     bot = make_bot(LanguageMechanics)
-    message = make_message(bot, '"!')
+    message = make_message(bot, '"hello"!')
     replies = get_replies(message)
     assert_equal "It is correct to keep the punctuation inside of the quotations, not outside of them.", replies.first
   end
 
+  def test_period_inside_of_quotation
+    bot = make_bot(LanguageMechanics)
+    message = make_message(bot, '"hello."')
+    replies = get_replies(message)
+    assert_equal nil, replies.first
+  end
+
   def test_period_outside_of_quotation
    bot = make_bot(LanguageMechanics)
-   message = make_message(bot, '".')
+   message = make_message(bot, '"hello".')
    replies = get_replies(message)
    assert_equal "It is correct to keep the punctuation inside of the quotations, not outside of them.", replies.first
   end
 
+  def test_question_mark_inside_of_quotation
+    bot = make_bot(LanguageMechanics)
+    message = make_message(bot, '"hello?"')
+    replies = get_replies(message)
+    assert_equal nil, replies.first
+  end
+
   def test_question_mark_outside_of_quotation
    bot = make_bot(LanguageMechanics)
-   message = make_message(bot, '"?')
+   message = make_message(bot, '"hello"?')
    replies = get_replies(message)
    assert_equal "It is correct to keep the punctuation inside of the quotations, not outside of them.", replies.first
+  end
+
+  def test_quotation_no_punctuation
+    bot = make_bot(LanguageMechanics)
+    message = make_message(bot, '"hello"')
+    replies = get_replies(message)
+    assert_equal nil, replies.first
   end
 
   def test_alot


### PR DESCRIPTION
Now people can type "class" without getting yelled at.  Also added the behavior for some other words to be safe.